### PR TITLE
Fix file commit history pagination

### DIFF
--- a/routes/repo/commit.go
+++ b/routes/repo/commit.go
@@ -45,6 +45,7 @@ func RenderIssueLinks(oldCommits *list.List, repoLink string) *list.List {
 func renderCommits(c *context.Context, filename string) {
 	c.Data["Title"] = c.Tr("repo.commits.commit_history") + " · " + c.Repo.Repository.FullName()
 	c.Data["PageIsCommits"] = true
+	c.Data["FileName"] = filename
 
 	page := c.QueryInt("page")
 	if page < 1 {


### PR DESCRIPTION
- The `commits_table.tmpl` pagination uses a `$.FileName` variable in
  order to generate the next/previous URLs, but it seems like that
  variable was no longer being populated in `renderCommits`.

The pull request will be closed without any reasons if it does not satisfy any of following requirements:

1. Please make sure you are targeting the `develop` branch.
2. Please read contributing guidelines:
https://github.com/gogits/gogs/wiki/Contributing-Code
3. Please describe what your pull request does and which issue you're targeting
4. ... if it is not related to any particular issues, explain why we should not reject your pull request.

**You MUST delete above content including this line before posting; too lazy to take this action considered invalid pull request.**
